### PR TITLE
Updated namespace for syropod_highlevel_controller bugfix

### DIFF
--- a/config/bullet_gazebo_controllers.yaml
+++ b/config/bullet_gazebo_controllers.yaml
@@ -1,198 +1,198 @@
-syropod:
-  # Publish all joint states -----------------------------------
-  joint_state_controller:
-    type: joint_state_controller/JointStateController
-    publish_rate: 50  
+
+# Publish all joint states -----------------------------------
+joint_state_controller:
+  type: joint_state_controller/JointStateController
+  publish_rate: 50  
+
+# Position Controllers ---------------------------------------
+
+
+# HEAD
+AL_coxa_joint:
+  type: effort_controllers/JointPositionController
+  joint: AL_coxa_joint
+  pid: {p: 50.0, i: 0.01, d: 0.01}
+
+
+
+AR_coxa_joint:
+  type: effort_controllers/JointPositionController
+  joint: AR_coxa_joint
+  pid: {p: 50.0, i: 0.01, d: 0.01}
+
+
+
+BL_coxa_joint:
+  type: effort_controllers/JointPositionController
+  joint: BL_coxa_joint
+  pid: {p: 50.0, i: 0.01, d: 0.01}
+
+
+
+BR_coxa_joint:
+  type: effort_controllers/JointPositionController
+  joint: BR_coxa_joint
+  pid: {p: 50.0, i: 0.01, d: 0.01}
+
+
+
+CL_coxa_joint:
+  type: effort_controllers/JointPositionController
+  joint: CL_coxa_joint
+  pid: {p: 50.0, i: 0.01, d: 0.01}
+
+
+
+CR_coxa_joint:
+  type: effort_controllers/JointPositionController
+  joint: CR_coxa_joint
+  pid: {p: 50.0, i: 0.01, d: 0.01}
+
+
+AL_coxat_joint:
+  type: effort_controllers/JointPositionController
+  joint: AL_coxat_joint
+  pid: {p: 50.0, i: 0.01, d: 0.01}
+
+AR_coxat_joint:
+  type: effort_controllers/JointPositionController
+  joint: AR_coxat_joint
+  pid: {p: 50.0, i: 0.01, d: 0.01}
+
+BL_coxat_joint:
+  type: effort_controllers/JointPositionController
+  joint: BL_coxat_joint
+  pid: {p: 50.0, i: 0.01, d: 0.01}
+
+
+BR_coxat_joint:
+  type: effort_controllers/JointPositionController
+  joint: BR_coxat_joint
+  pid: {p: 50.0, i: 0.01, d: 0.01}
+
+CL_coxat_joint:
+  type: effort_controllers/JointPositionController
+  joint: CL_coxat_joint
+  pid: {p: 50.0, i: 0.01, d: 0.01}
+
+CR_coxat_joint:
+  type: effort_controllers/JointPositionController
+  joint: CR_coxat_joint
+  pid: {p: 50.0, i: 0.01, d: 0.01}    
+
+
+AL_femur_joint:
+  type: effort_controllers/JointPositionController
+  joint: AL_femur_joint
+  pid: {p: 50.0, i: 0.01, d: 0.01}
+
+
+
+AR_femur_joint:
+  type: effort_controllers/JointPositionController
+  joint: AR_femur_joint
+  pid: {p: 50.0, i: 0.01, d: 0.01}
+
+
+
+BL_femur_joint:
+  type: effort_controllers/JointPositionController
+  joint: BL_femur_joint
+  pid: {p: 50.0, i: 0.01, d: 0.01}
+
+
+
+BR_femur_joint:
+  type: effort_controllers/JointPositionController
+  joint: BR_femur_joint
+  pid: {p: 50.0, i: 0.01, d: 0.01}
+
+
+
+CL_femur_joint:
+  type: effort_controllers/JointPositionController
+  joint: CL_femur_joint
+  pid: {p: 50.0, i: 0.01, d: 0.01}
+
+
+
+CR_femur_joint:
+  type: effort_controllers/JointPositionController
+  joint: CR_femur_joint
+  pid: {p: 50.0, i: 0.01, d: 0.01}
+
+
+
+AL_tibia_joint:
+  type: effort_controllers/JointPositionController
+  joint: AL_tibia_joint
+  pid: {p: 50.0, i: 0.01, d: 0.01}
+
+
+
+AR_tibia_joint:
+  type: effort_controllers/JointPositionController
+  joint: AR_tibia_joint
+  pid: {p: 50.0, i: 0.01, d: 0.01}
+
+
+
+BL_tibia_joint:
+  type: effort_controllers/JointPositionController
+  joint: BL_tibia_joint
+  pid: {p: 50.0, i: 0.01, d: 0.01}
+
+
+
+BR_tibia_joint:
+  type: effort_controllers/JointPositionController
+  joint: BR_tibia_joint
+  pid: {p: 50.0, i: 0.01, d: 0.01}
+
+
+
+CL_tibia_joint:
+  type: effort_controllers/JointPositionController
+  joint: CL_tibia_joint
+  pid: {p: 50.0, i: 0.01, d: 0.01}
+
+
+
+CR_tibia_joint:
+  type: effort_controllers/JointPositionController
+  joint: CR_tibia_joint
+  pid: {p: 50.0, i: 0.01, d: 0.01}
   
-  # Position Controllers ---------------------------------------
+AR_tarsus_joint:
+  type: effort_controllers/JointPositionController
+  joint: AR_tarsus_joint
+  pid: {p: 50.0, i: 0.01, d: 0.01}
 
+AL_tarsus_joint:
+  type: effort_controllers/JointPositionController
+  joint: AL_tarsus_joint
+  pid: {p: 50.0, i: 0.01, d: 0.01}
 
-  # HEAD
-  AL_coxa_joint:
-    type: effort_controllers/JointPositionController
-    joint: AL_coxa_joint
-    pid: {p: 50.0, i: 0.01, d: 0.01}
 
+BR_tarsus_joint:
+  type: effort_controllers/JointPositionController
+  joint: BR_tarsus_joint
+  pid: {p: 50.0, i: 0.01, d: 0.01}
 
 
-  AR_coxa_joint:
-    type: effort_controllers/JointPositionController
-    joint: AR_coxa_joint
-    pid: {p: 50.0, i: 0.01, d: 0.01}
+BL_tarsus_joint:
+  type: effort_controllers/JointPositionController
+  joint: BL_tarsus_joint
+  pid: {p: 50.0, i: 0.01, d: 0.01}
 
 
+CR_tarsus_joint:
+  type: effort_controllers/JointPositionController
+  joint: CR_tarsus_joint
+  pid: {p: 50.0, i: 0.01, d: 0.01}
 
-  BL_coxa_joint:
-    type: effort_controllers/JointPositionController
-    joint: BL_coxa_joint
-    pid: {p: 50.0, i: 0.01, d: 0.01}
 
-
-
-  BR_coxa_joint:
-    type: effort_controllers/JointPositionController
-    joint: BR_coxa_joint
-    pid: {p: 50.0, i: 0.01, d: 0.01}
-
-
-
-  CL_coxa_joint:
-    type: effort_controllers/JointPositionController
-    joint: CL_coxa_joint
-    pid: {p: 50.0, i: 0.01, d: 0.01}
-
-
-
-  CR_coxa_joint:
-    type: effort_controllers/JointPositionController
-    joint: CR_coxa_joint
-    pid: {p: 50.0, i: 0.01, d: 0.01}
-
-
-  AL_coxat_joint:
-    type: effort_controllers/JointPositionController
-    joint: AL_coxat_joint
-    pid: {p: 50.0, i: 0.01, d: 0.01}
-
-  AR_coxat_joint:
-    type: effort_controllers/JointPositionController
-    joint: AR_coxat_joint
-    pid: {p: 50.0, i: 0.01, d: 0.01}
-
-  BL_coxat_joint:
-    type: effort_controllers/JointPositionController
-    joint: BL_coxat_joint
-    pid: {p: 50.0, i: 0.01, d: 0.01}
-
-
-  BR_coxat_joint:
-    type: effort_controllers/JointPositionController
-    joint: BR_coxat_joint
-    pid: {p: 50.0, i: 0.01, d: 0.01}
-
-  CL_coxat_joint:
-    type: effort_controllers/JointPositionController
-    joint: CL_coxat_joint
-    pid: {p: 50.0, i: 0.01, d: 0.01}
-
-  CR_coxat_joint:
-    type: effort_controllers/JointPositionController
-    joint: CR_coxat_joint
-    pid: {p: 50.0, i: 0.01, d: 0.01}    
-
-
-  AL_femur_joint:
-    type: effort_controllers/JointPositionController
-    joint: AL_femur_joint
-    pid: {p: 50.0, i: 0.01, d: 0.01}
-
-
-
-  AR_femur_joint:
-    type: effort_controllers/JointPositionController
-    joint: AR_femur_joint
-    pid: {p: 50.0, i: 0.01, d: 0.01}
-
-
-
-  BL_femur_joint:
-    type: effort_controllers/JointPositionController
-    joint: BL_femur_joint
-    pid: {p: 50.0, i: 0.01, d: 0.01}
-
-
-
-  BR_femur_joint:
-    type: effort_controllers/JointPositionController
-    joint: BR_femur_joint
-    pid: {p: 50.0, i: 0.01, d: 0.01}
-
-
-
-  CL_femur_joint:
-    type: effort_controllers/JointPositionController
-    joint: CL_femur_joint
-    pid: {p: 50.0, i: 0.01, d: 0.01}
-
-
-
-  CR_femur_joint:
-    type: effort_controllers/JointPositionController
-    joint: CR_femur_joint
-    pid: {p: 50.0, i: 0.01, d: 0.01}
-
-
-
-  AL_tibia_joint:
-    type: effort_controllers/JointPositionController
-    joint: AL_tibia_joint
-    pid: {p: 50.0, i: 0.01, d: 0.01}
-
-
-
-  AR_tibia_joint:
-    type: effort_controllers/JointPositionController
-    joint: AR_tibia_joint
-    pid: {p: 50.0, i: 0.01, d: 0.01}
-
-
-
-  BL_tibia_joint:
-    type: effort_controllers/JointPositionController
-    joint: BL_tibia_joint
-    pid: {p: 50.0, i: 0.01, d: 0.01}
-
-
-
-  BR_tibia_joint:
-    type: effort_controllers/JointPositionController
-    joint: BR_tibia_joint
-    pid: {p: 50.0, i: 0.01, d: 0.01}
-
-
-
-  CL_tibia_joint:
-    type: effort_controllers/JointPositionController
-    joint: CL_tibia_joint
-    pid: {p: 50.0, i: 0.01, d: 0.01}
-
-
-
-  CR_tibia_joint:
-    type: effort_controllers/JointPositionController
-    joint: CR_tibia_joint
-    pid: {p: 50.0, i: 0.01, d: 0.01}
-    
-  AR_tarsus_joint:
-    type: effort_controllers/JointPositionController
-    joint: AR_tarsus_joint
-    pid: {p: 50.0, i: 0.01, d: 0.01}
-
-  AL_tarsus_joint:
-    type: effort_controllers/JointPositionController
-    joint: AL_tarsus_joint
-    pid: {p: 50.0, i: 0.01, d: 0.01}
-
-
-  BR_tarsus_joint:
-    type: effort_controllers/JointPositionController
-    joint: BR_tarsus_joint
-    pid: {p: 50.0, i: 0.01, d: 0.01}
-
-
-  BL_tarsus_joint:
-    type: effort_controllers/JointPositionController
-    joint: BL_tarsus_joint
-    pid: {p: 50.0, i: 0.01, d: 0.01}
-
-
-  CR_tarsus_joint:
-    type: effort_controllers/JointPositionController
-    joint: CR_tarsus_joint
-    pid: {p: 50.0, i: 0.01, d: 0.01}
-
-
-  CL_tarsus_joint:
-    type: effort_controllers/JointPositionController
-    joint: CL_tarsus_joint
-    pid: {p: 50.0, i: 0.01, d: 0.01}
+CL_tarsus_joint:
+  type: effort_controllers/JointPositionController
+  joint: CL_tarsus_joint
+  pid: {p: 50.0, i: 0.01, d: 0.01}

--- a/launch/bullet_gazebo.launch
+++ b/launch/bullet_gazebo.launch
@@ -20,7 +20,7 @@
   </include>
 
   <!-- Load the URDF into the ROS Parameter Server -->
-  <param name="robot_description" command="$(find xacro)/xacro $(find bullet_syropod)/robot/bullet.xacro" />
+  <param name="robot_description" command="$(find xacro)/xacro $(find bullet_syropod)/robot/bullet.xacro"/>
 
   <param name="box_description" command="$(find xacro)/xacro $(find bullet_syropod)/robot/robot_box.urdf" />
 
@@ -28,7 +28,7 @@
   <rosparam file="$(find bullet_syropod)/config/bullet_gazebo_controllers.yaml" command="load"/>
 
   <!-- load the controllers -->
-  <node name="controller_spawner" pkg="controller_manager" type="spawner" respawn="false" output="screen" ns="/syropod" args="joint_state_controller
+  <node name="controller_spawner" pkg="controller_manager" type="spawner" respawn="false" output="screen" args="joint_state_controller
                                         AL_coxa_joint 
                                         AR_coxa_joint 
                                         BL_coxa_joint 
@@ -113,6 +113,6 @@
 
   <!-- convert joint states to TF transforms for rviz, etc -->
   <node name="robot_state_publisher" pkg="robot_state_publisher" type="robot_state_publisher" respawn="false" output="screen">
-    <remap from="/joint_states" to="/syropod/joint_states" />
+    <!-- <remap from="/joint_states" to="/syropod/joint_states" /> -->
   </node>
 </launch>

--- a/launch/bullet_gazebo.launch
+++ b/launch/bullet_gazebo.launch
@@ -113,6 +113,5 @@
 
   <!-- convert joint states to TF transforms for rviz, etc -->
   <node name="robot_state_publisher" pkg="robot_state_publisher" type="robot_state_publisher" respawn="false" output="screen">
-    <!-- <remap from="/joint_states" to="/syropod/joint_states" /> -->
   </node>
 </launch>

--- a/robot/bullet.xacro
+++ b/robot/bullet.xacro
@@ -12,7 +12,6 @@
 
 	<gazebo>
 		<plugin name="gazebo_ros_control" filename="libgazebo_ros_control.so">
-			<robotNamespace></robotNamespace>
 		</plugin>
 
 		<plugin name="imu_plugin" filename="libgazebo_ros_imu.so">

--- a/robot/bullet.xacro
+++ b/robot/bullet.xacro
@@ -12,13 +12,13 @@
 
 	<gazebo>
 		<plugin name="gazebo_ros_control" filename="libgazebo_ros_control.so">
-			<robotNamespace>/syropod</robotNamespace>
+			<robotNamespace></robotNamespace>
 		</plugin>
 
 		<plugin name="imu_plugin" filename="libgazebo_ros_imu.so">
 			<alwaysOn>true</alwaysOn>
 			<bodyName>base_link</bodyName>
-			<topicName>imu</topicName>
+			<topicName>imu/data</topicName>
 			<serviceName>imu_service</serviceName>
 			<gaussianNoise>0.0</gaussianNoise>
 			<updateRate>20.0</updateRate>


### PR DESCRIPTION
This PR is related to the changes made in https://github.com/csiro-robotics/syropod_highlevel_controller/pull/11. Updated configs/launch files to work with the remove of syropod from namespace. Also updated default IMU topic in gazebo plugin for https://github.com/csiro-robotics/syropod_highlevel_controller/pull/13. 